### PR TITLE
Allow integer-valued rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ When `delay_framing` is set to `delay`, then future rewards will be presented in
 
 When `delay_framing` is set to `date`, then future rewards will be presented as occurring on a particular date.
 
+### Whole-numbered rewards
+For some experiments it doesn't make sense to offer fractional reward values. If you want to constrain rewards to take on integer values then you can specify this in the construction of the `Experiment` object with the key-value pair of (`'reward_type', 'integer'`), for example...
+
+```Matlab
+expt = Experiment(myModel, 'reward_type', 'integer');
+```
+
 ### Need even more options?
 The easiest way to add more framing options is to either go and edit the `getHumanResponse.m` file, or to create a feature request.
 

--- a/darc-experiments/human_get_response_code/getHumanResponse.m
+++ b/darc-experiments/human_get_response_code/getHumanResponse.m
@@ -49,6 +49,11 @@ switch opts.commodity_type
         commodity.prefix = '';
         commodity.suffix = ' bars of chocolate';
         
+    case{'presentation'}
+        % used in an experiment on social anxiety
+        commodity.prefix = 'presenting to a crowd of ';
+        commodity.suffix = ' people';
+        
     otherwise
         error('requested commodity_type not defined')
 end

--- a/darc-experiments/human_get_response_code/getHumanResponse.m
+++ b/darc-experiments/human_get_response_code/getHumanResponse.m
@@ -59,7 +59,11 @@ switch opts.commodity_type
 end
 
 % compose reward (eg $100, or 15 dohnuts)
-offerStr = [commodity.prefix sprintf('%.2f', prospect.reward) commodity.suffix];
+if rem(prospect.reward,1)==0 % integer valued reward
+    offerStr = [commodity.prefix sprintf('%d', prospect.reward) commodity.suffix];
+else % non-whole number reward
+    offerStr = [commodity.prefix sprintf('%.2f', prospect.reward) commodity.suffix];
+end
 
 %% Compose delay string
 switch opts.delay_framing

--- a/darc-toolbox/Experiment.m
+++ b/darc-toolbox/Experiment.m
@@ -47,7 +47,6 @@ classdef Experiment
         %all_reaction_times
         human_response_options % key/value pairs... cell array of strings
         data_table
-        
         % string of optional text to include in the filename of saved
         % files. This will be used in addition to default information such
         % as the participant ID, date, time, and model name.
@@ -78,6 +77,7 @@ classdef Experiment
             userArgs.addParameter('expt_options', struct(), @isstruct)
             userArgs.addParameter('trials', 30, @isnumeric)
             userArgs.addParameter('human_response_options', {}, @iscellstr)
+            userArgs.addParameter('reward_type', 'real', @(x) any(strcmp(x,{'real','integer'})));
             userArgs.parse(varargin{:});
             
             obj.userArgs = userArgs.Results;
@@ -359,6 +359,14 @@ classdef Experiment
                     % injection by providing our own user-defined function
                     % in the Experiment constructor.
                     [prospectA, prospectB] = obj.model.design2prospects(chosen_design);
+                    
+                    % Set rewards of prospects to be integer, if we have
+                    % asked for that
+                    switch obj.userArgs.reward_type
+                        case{'integer'}
+                            prospectA.reward = round(prospectA.reward);
+                            prospectB.reward = round(prospectB.reward);
+                    end
                     
                     response_object = getHumanResponse(prospectA, prospectB,...
                         obj.human_response_options{:});


### PR DESCRIPTION
This implements changes we need to run an experiment on social anxiety where the prospect is presenting in front of X people. Presenting in front of 23.4 people doesn't make any sense, so I've added an option to force rewards to be whole numbers only.